### PR TITLE
update spawner RestartNeverでspawn中にエラーになったユーザーを再spawnされないようにしてスパイクを防止

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -73,7 +73,7 @@ type LoadGenerator struct {
 // NewLoadGenerator returns a new LoadGenerator.
 func NewLoadGenerator() *LoadGenerator {
 	return &LoadGenerator{
-		RestartMode:           spawner.RestartNever,
+		RestartMode:           spawner.RestartLocustCompatible,
 		StatsNotifyInterval:   defaultStatsNotifyInterval,
 		StatsAggregationUsers: defaultStatsAggregationUsers,
 

--- a/spawner/spawner.go
+++ b/spawner/spawner.go
@@ -30,8 +30,14 @@ type RestartMode int
 type SpawnFunc func(ctx context.Context)
 
 const (
-	// RestartNever is a mode where goroutines are not restarted once they finish.
-	RestartNever RestartMode = iota
+	// RestartLocustCompatible backfills a finished goroutine's slot on the next Cap call,
+	// matching the original Locust worker; goroutines finishing early (e.g. a failing
+	// OnStart) can make spawns per Cap call snowball. Use RestartNever to avoid that.
+	RestartLocustCompatible RestartMode = iota
+	// RestartNever never backfills a slot once a goroutine finishes on its own, unlike
+	// RestartLocustCompatible. A slot freed by Cap reducing the capacity is still given
+	// back, so a later Cap increase can spawn up to the new capacity.
+	RestartNever
 	// RestartAlways is a mode that ensures goroutines are automatically restarted to maintain the capacity.
 	RestartAlways
 )
@@ -42,6 +48,8 @@ type Spawner struct {
 	spawnFunc SpawnFunc
 	count     int64
 	spawned   int64
+
+	totalSpawned int64
 
 	spawnChMutex sync.Mutex
 	spawnCh      chan struct{}
@@ -72,10 +80,16 @@ func (s *Spawner) Cap(count int) {
 
 	if s.isRunning() {
 		// spawnWorker が動いている場合は一度止めて別の spawnWorkerを動かす
-		s.spawnWorker(count)
+		s.spawnWorker(count, false)
 	} else {
 		// spawnWorker が動いていない場合はユーザーリストの上限のみ変更
-		s.threads.Cap(count)
+		s.reclaim(s.threads.Cap(count))
+	}
+}
+
+func (s *Spawner) reclaim(canceled int) {
+	if canceled > 0 {
+		atomic.AddInt64(&s.totalSpawned, -int64(canceled))
 	}
 }
 
@@ -86,7 +100,7 @@ func (s *Spawner) Count() int64 {
 
 // Start starts the goroutine manager.
 func (s *Spawner) Start() {
-	s.spawnWorker(int(atomic.LoadInt64(&s.count)))
+	s.spawnWorker(int(atomic.LoadInt64(&s.count)), true)
 }
 
 // Stop stops the goroutine manager.
@@ -116,7 +130,7 @@ func (s *Spawner) isRunning() bool {
 	return s.stop != nil
 }
 
-func (s *Spawner) spawnWorker(count int) {
+func (s *Spawner) spawnWorker(count int, reset bool) {
 	spawnCh := make(chan struct{}, count)
 	stopCh := make(chan struct{})
 	stopWaitCh := make(chan struct{})
@@ -124,6 +138,11 @@ func (s *Spawner) spawnWorker(count int) {
 	s.stopMutex.Lock()
 	if s.stop != nil {
 		s.stop()
+	}
+	if reset {
+		// 前回の spawn goroutine が完全に停止したのを確認したあとで
+		// 累計 spawn 数をリセットする
+		atomic.StoreInt64(&s.totalSpawned, 0)
 	}
 	s.stop = func() {
 		// spawn用の goroutine に停止の指令を出して、 goroutine が終了するのを待つ
@@ -139,16 +158,21 @@ func (s *Spawner) spawnWorker(count int) {
 
 	// 旧 spawnCh から新 spawnCh にユーザーのロックを移し、溢れた場合はユーザーを捨てる
 	s.migrateSpawnCh(oldSpawnCh, spawnCh)
-	s.threads.Cap(count)
+	s.reclaim(s.threads.Cap(count))
 
-	if s.mode == RestartNever {
-		go s.spawnWorkerOnce(spawnCh, stopCh, stopWaitCh)
-	} else if s.mode == RestartAlways {
+	switch s.mode {
+	case RestartLocustCompatible:
+		go s.spawnWorkerLocustCompatible(spawnCh, stopCh, stopWaitCh)
+	case RestartNever:
+		// 累計 spawn 数が count に満たない分だけ新規に spawn する
+		budget := max(0, count-int(atomic.LoadInt64(&s.totalSpawned)))
+		go s.spawnWorkerOnce(spawnCh, stopCh, stopWaitCh, budget)
+	case RestartAlways:
 		go s.spawnWorkerPersistent(spawnCh, stopCh, stopWaitCh)
 	}
 }
 
-func (s *Spawner) spawnWorkerOnce(spawnCh, stopCh, stopWaitCh chan struct{}) {
+func (s *Spawner) spawnWorkerLocustCompatible(spawnCh, stopCh, stopWaitCh chan struct{}) {
 	defer close(stopWaitCh)
 	defer close(spawnCh)
 
@@ -163,6 +187,22 @@ func (s *Spawner) spawnWorkerOnce(spawnCh, stopCh, stopWaitCh chan struct{}) {
 
 		default:
 			// 指定数を起動したので終了
+			return
+		}
+	}
+}
+
+func (s *Spawner) spawnWorkerOnce(spawnCh, stopCh, stopWaitCh chan struct{}, budget int) {
+	defer close(stopWaitCh)
+	defer close(spawnCh)
+
+	for n := 0; n < budget; n++ {
+		select {
+		case spawnCh <- struct{}{}:
+			// budget の範囲内でのみユーザーを新規に spawn させる
+			s.spawn()
+
+		case <-stopCh:
 			return
 		}
 	}
@@ -185,6 +225,8 @@ func (s *Spawner) spawnWorkerPersistent(spawnCh, stopCh, stopWaitCh chan struct{
 }
 
 func (s *Spawner) spawn() {
+	atomic.AddInt64(&s.totalSpawned, 1)
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	s.threadMutex.Lock()
@@ -217,7 +259,7 @@ func (s *Spawner) migrateSpawnCh(src, dst chan struct{}) {
 	if cap(dst) == 0 {
 		// cap が 0 に更新された場合は動いているユーザーを全て捨てる
 		for v := range src {
-			s.threads.Pop(1)
+			s.reclaim(s.threads.Pop(1))
 			dst <- v
 		}
 		return
@@ -241,7 +283,7 @@ loop:
 			// 移行先の channel に spawn のロックを移せられれば次のロックを取り出す
 		default:
 			// 移行先の channel が一杯の場合はユーザーを1つ捨ててからロックを移す
-			s.threads.Pop(1)
+			s.reclaim(s.threads.Pop(1))
 			dst <- v
 		}
 	}

--- a/spawner/spawner_test.go
+++ b/spawner/spawner_test.go
@@ -93,7 +93,7 @@ func NewSpawner(mode spawner.RestartMode) (*spawner.Spawner, *SpawnTask) {
 }
 
 func TestSpawner_Start(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	s.Start()
 	defer func() {
@@ -109,7 +109,7 @@ func TestSpawner_Start(t *testing.T) {
 }
 
 func TestSpawner_Cap_BeforeStart(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	s.Cap(3)
 	s.Start()
@@ -134,7 +134,7 @@ func TestSpawner_Cap_BeforeStart(t *testing.T) {
 }
 
 func TestSpawner_Cap_AfterStart(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	s.Start()
 	s.Cap(3)
@@ -159,7 +159,7 @@ func TestSpawner_Cap_AfterStart(t *testing.T) {
 }
 
 func TestSpawner_Cap_Extension(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	s.Cap(3)
 	s.Start()
@@ -194,7 +194,7 @@ func TestSpawner_Cap_Extension(t *testing.T) {
 }
 
 func TestSpawner_Cap_Shrink(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	s.Cap(3)
 	s.Start()
@@ -228,7 +228,7 @@ func TestSpawner_Cap_Shrink(t *testing.T) {
 }
 
 func TestSpawner_Cap_ShrinkMultiple(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	s.Cap(6)
 	s.Start()
@@ -276,6 +276,207 @@ func TestSpawner_Cap_ShrinkMultiple(t *testing.T) {
 	}
 }
 
+func TestSpawner_RestartNever_Cap_AfterStart(t *testing.T) {
+	s, st := NewSpawner(spawner.RestartNever)
+
+	s.Start()
+	s.Cap(3)
+
+	st.WaitStart(3)
+	if n := st.Started(); n != 3 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 3)
+	}
+	if n := st.Stopped(); n != 0 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", n, 0)
+	}
+
+	s.Cap(5)
+
+	st.WaitStart(5)
+	if n := st.Started(); n != 5 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 5)
+	}
+	if n := st.Stopped(); n != 0 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", n, 0)
+	}
+
+	s.Stop()
+	s.StopAllThreads()
+
+	if n := st.Started(); n != 5 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 5)
+	}
+	if n := st.Stopped(); n != 5 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", n, 5)
+	}
+}
+
+// TestSpawner_RestartNever_Cap_Shrink は、Cap の縮小で強制キャンセルされたスレッドは、
+// target を再度増やした際に累計 spawn 数から差し引かれている分だけ
+// 新規に spawn され直すことを確認する。
+func TestSpawner_RestartNever_Cap_Shrink(t *testing.T) {
+	s, st := NewSpawner(spawner.RestartNever)
+
+	s.Cap(3)
+	s.Start()
+
+	st.WaitStart(3)
+	if n := st.Started(); n != 3 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 3)
+	}
+
+	s.Cap(1)
+	st.WaitStop(2)
+
+	if n := st.Started(); n != 3 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 3)
+	}
+	if n := st.Stopped(); n != 2 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", n, 2)
+	}
+
+	// target を縮小前の 3 に戻すと、強制キャンセルされた 2 スロット分の
+	// 累計 spawn 数が戻っているため、新規に 2 件 spawn される
+	s.Cap(3)
+
+	st.WaitStart(5)
+	if n := st.Started(); n != 5 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 5)
+	}
+
+	s.Stop()
+	s.StopAllThreads()
+
+	if n := st.Stopped(); n != 5 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", n, 5)
+	}
+}
+
+// TestSpawner_RestartNever_ShrinkRegrow_KeepsFailedSlotsUnfilled は、
+// OnStart 失敗のように自ら終了したスレッドのスロットは再拡大しても埋め直されない一方、
+// Cap の縮小で強制キャンセルされたスレッドのスロットは再拡大時に埋め直されることを
+// 同時に確認する。
+func TestSpawner_RestartNever_ShrinkRegrow_KeepsFailedSlotsUnfilled(t *testing.T) {
+	s, st := NewSpawner(spawner.RestartNever)
+
+	// 最初に完了した 2 件は OnStart 失敗を模して即終了、残りはブロックし続ける
+	var n atomic.Int64
+	st.TaskFunc = func(ctx context.Context) {
+		if n.Add(1) <= 2 {
+			return
+		}
+		<-ctx.Done()
+	}
+
+	s.Start()
+	s.Cap(4)
+
+	st.WaitStart(4)
+	st.WaitStop(2)
+
+	if got := st.Started(); got != 4 {
+		t.Fatalf("unexpected started user. got:%d want:%d", got, 4)
+	}
+	if got := st.Stopped(); got != 2 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", got, 2)
+	}
+
+	// 残り2件が生存したまま target を 4 に保っても、自然終了した 2 件分は埋め直されない
+	time.Sleep(100 * time.Millisecond)
+	if got := st.Started(); got != 4 {
+		t.Fatalf("unexpected started user after settle. got:%d want:%d", got, 4)
+	}
+
+	// 生存中の残り 2 件を Cap(0) で強制キャンセルする
+	s.Cap(0)
+	st.WaitStop(4)
+	if got := st.Stopped(); got != 4 {
+		t.Fatalf("unexpected stopped user. got:%d want:%d", got, 4)
+	}
+
+	// 縮小前の target 4 まで再拡大すると、強制キャンセルされた 2 件分のみ
+	// 新規に spawn される (自然終了 (失敗) した 2 件分は復活しない)
+	s.Cap(4)
+
+	st.WaitStart(6)
+	if got := st.Started(); got != 6 {
+		t.Fatalf("unexpected started user. got:%d want:%d", got, 6)
+	}
+
+	s.Stop()
+	s.StopAllThreads()
+}
+
+// TestSpawner_RestartNever_NoBackfill は、一度 spawn したスロットが失敗などで即終了した場合でも、
+// target を増やした際に累計 spawn 数を基準に不足分のみを spawn し、
+// 終了済みのスロットを埋め直さないことを確認する。
+func TestSpawner_RestartNever_NoBackfill(t *testing.T) {
+	s, st := NewSpawner(spawner.RestartNever)
+
+	// OnStart が即座に失敗して終了するケースを模倣し、タスクを即終了させる
+	st.TaskFunc = func(ctx context.Context) {}
+
+	s.Start()
+	s.Cap(3)
+
+	st.WaitStart(3)
+	st.WaitStop(3)
+
+	if n := st.Started(); n != 3 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 3)
+	}
+
+	// target を 3 から 5 に増やしても、現在生きているユーザーは 0 人だが、
+	// 累計 spawn 数 (3) を基準に不足分 (5-3=2) だけが新規に spawn される。
+	// 現在生きている数 (0) を基準にすると 5 件 spawn されてしまい、started は 8 になるはず。
+	s.Cap(5)
+
+	st.WaitStart(5)
+	st.WaitStop(5)
+
+	if n := st.Started(); n != 5 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 5)
+	}
+
+	s.Stop()
+	s.StopAllThreads()
+}
+
+// TestSpawner_RestartNever_Start_ResetsTotalSpawned は、Start() の呼び出しで
+// 累計 spawn 数がリセットされ、新しいテスト実行では改めて target 分まで
+// spawn できることを確認する。
+func TestSpawner_RestartNever_Start_ResetsTotalSpawned(t *testing.T) {
+	s, st := NewSpawner(spawner.RestartNever)
+	st.TaskFunc = func(ctx context.Context) {}
+
+	s.Start()
+	s.Cap(3)
+
+	st.WaitStart(3)
+	st.WaitStop(3)
+
+	s.Stop()
+	s.StopAllThreads()
+
+	if n := st.Started(); n != 3 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 3)
+	}
+
+	// 新しいテスト実行を模倣 (LoadGenerator.Start() と同様に Cap(0) してから Start())
+	s.Cap(0)
+	s.Start()
+	s.Cap(2)
+
+	// リセットされていなければ budget は 2-3<0 で 0 件になり、started は 3 のまま変わらない
+	st.WaitStart(5)
+	if n := st.Started(); n != 5 {
+		t.Fatalf("unexpected started user. got:%d want:%d", n, 5)
+	}
+
+	s.Stop()
+	s.StopAllThreads()
+}
+
 func TestSpawner_SpawnPersistent(t *testing.T) {
 	s, st := NewSpawner(spawner.RestartAlways)
 
@@ -316,7 +517,7 @@ func TestSpawner_SpawnPersistent(t *testing.T) {
 }
 
 func TestSpawner_StopAllThreads(t *testing.T) {
-	s, st := NewSpawner(spawner.RestartNever)
+	s, st := NewSpawner(spawner.RestartLocustCompatible)
 
 	ctx2, cancel := context.WithCancel(context.Background())
 

--- a/spawner/thread.go
+++ b/spawner/thread.go
@@ -33,14 +33,15 @@ type threadList struct {
 	currentID uint64
 }
 
-func (tl *threadList) Cap(n int) {
+func (tl *threadList) Cap(n int) int {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
 	tl.count = n
-	tl.pop(len(tl.threads) - n)
+	canceled := tl.pop(len(tl.threads) - n)
 	old := tl.threads
 	tl.threads = make([]thread, len(old), n)
 	copy(tl.threads, old)
+	return canceled
 }
 
 func (tl *threadList) Add(cancel func()) uint64 {
@@ -55,10 +56,10 @@ func (tl *threadList) Add(cancel func()) uint64 {
 	return tl.currentID
 }
 
-func (tl *threadList) Pop(n int) {
+func (tl *threadList) Pop(n int) int {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
-	tl.pop(n)
+	return tl.pop(n)
 }
 
 func (tl *threadList) Delete(id uint64) {
@@ -79,14 +80,15 @@ func (tl *threadList) Clear() {
 	tl.pop(len(tl.threads))
 }
 
-func (tl *threadList) pop(n int) {
+func (tl *threadList) pop(n int) int {
 	n = min(n, len(tl.threads))
 	if n <= 0 {
-		return
+		return 0
 	}
 	deleted := tl.threads[:n]
 	tl.threads = tl.threads[n:]
 	for _, u := range deleted {
 		u.cancel()
 	}
+	return n
 }

--- a/worker_option.go
+++ b/worker_option.go
@@ -47,7 +47,7 @@ func WithCatchExceptions(catch bool) WorkerOption {
 }
 
 // WithRestartMode sets the mode of spawning users.
-// default is spawner.RestartNever.
+// default is spawner.RestartLocustCompatible.
 func WithRestartMode(mode spawner.RestartMode) WorkerOption {
 	return func(w *Worker) {
 		w.loadGenerator.RestartMode = mode


### PR DESCRIPTION
* 元のRestartNeverの挙動はRestartLocustCompatibleとして実装し、デフォルト値もそれに変更